### PR TITLE
Updated the project to compile against Spring boot 2 and Spring framework 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- Dependencies -->
+        <beanmapper.version>2.4.1</beanmapper.version>
+        <database.truncator.version>0.5.1.SPRING5</database.truncator.version>
+        <h2database.version>1.4.196</h2database.version>
+        <spring.boot.version>2.0.3.RELEASE</spring.boot.version>
+
         <slf4j.version>1.7.2</slf4j.version>
         <!-- Reporting -->
         <maven.cobertura.version>2.4</maven.cobertura.version>
@@ -72,32 +78,32 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper</artifactId>
-            <version>2.4.0</version>
+            <version>${beanmapper.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>1.4.3.RELEASE</version>
+            <version>${spring.boot.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>1.4.3.RELEASE</version>
+            <version>${spring.boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.196</version>
+            <version>${h2database.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.42</groupId>
             <artifactId>database-truncator</artifactId>
-            <version>0.5.1</version>
+            <version>${database.truncator.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/nl/_42/heph/PersonRepositoryTest.java
+++ b/src/test/java/nl/_42/heph/PersonRepositoryTest.java
@@ -9,6 +9,7 @@ import nl._42.heph.domain.Person;
 import nl._42.heph.domain.PersonRepository;
 import nl._42.heph.shared.AbstractSpringTest;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -22,7 +23,8 @@ public class PersonRepositoryTest extends AbstractSpringTest {
         Person person = new Person();
         person.setName("Henk");
         personRepository.save(person);
-        Person retrievedPerson = personRepository.findOne(person.getId());
+        Assert.assertNotNull(person.getId());
+        Person retrievedPerson = personRepository.findById(person.getId()).orElseThrow(() -> new IllegalStateException("Person was not saved in the database."));
         assertEquals(person.getName(), retrievedPerson.getName());
     }
 


### PR DESCRIPTION
Updated the project to compile against Spring boot 2 and Spring framework 5.

Even though there are no changes in the main source files, it was necessary to update the project since it needs to rely on an updated implementation of the Persistable interface (from Spring Data 2.0.8). Otherwise, a NoSuchMethodError is thrown when this library tries to use the getId() method of the incompatible class definition from Spring Data 1.x.