### PR TITLE
Implemented auto-generation of BuilderConstructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Made the BuilderConstructors optional. Builders no longer have to override the method `constructors()` 
+and BuildCommands no longer need 2 constructors (with Entity and Supplier<Entity>).
 
 ## [0.1.1] - 2018-05-18
 ### Fixed

--- a/src/main/java/nl/_42/heph/AbstractBuildCommand.java
+++ b/src/main/java/nl/_42/heph/AbstractBuildCommand.java
@@ -66,7 +66,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public abstract class AbstractBuildCommand<T extends Persistable> {
 
     /** the entity which is wrapped by the BuildCommand */
-    private final T entity;
+    private T entity;
     /**
      * all the references which need to be resolved BEFORE a findEntity is executed, eg
      * when part of said method's parameters. Ie, early resolution.
@@ -78,7 +78,14 @@ public abstract class AbstractBuildCommand<T extends Persistable> {
      * if true, states that no attempt will be made to find an already existing entity.
      * This mode is enabled when a copy or update has been called.
      */
-    private final boolean updating;
+    private boolean updating;
+
+    /**
+     * Required constructor, gets called by reflection in AbstractBuilder when getConstructors() has not been overridden.
+     * (generateDefaultBuilderConstructors()).
+     */
+    public AbstractBuildCommand() {
+    }
 
     /**
      * Creates the BuildCommand by wrapping the entity. The entity supplied

--- a/src/main/java/nl/_42/heph/AbstractBuilder.java
+++ b/src/main/java/nl/_42/heph/AbstractBuilder.java
@@ -1,11 +1,19 @@
 package nl._42.heph;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.beanmapper.BeanMapper;
 
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.GenericTypeResolver;
 import org.springframework.data.domain.Persistable;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * <p>
@@ -27,6 +35,8 @@ import org.springframework.data.domain.Persistable;
  */
 public abstract class AbstractBuilder<T extends Persistable, BC extends AbstractBuildCommand> {
 
+    private BuilderConstructors<T, BC> defaultBuilderConstructors;
+
     /**
      * BeanMapper is used when the copy function is invoked. It will attempt to make a clear
      * copy. Be aware that non-traditional getters/setters may hamper the working of the copy
@@ -36,12 +46,21 @@ public abstract class AbstractBuilder<T extends Persistable, BC extends Abstract
     private BeanMapper beanMapper;
 
     /**
-     * Method which must provide the three constructors; i) constructor for the BuildCommand
+     * Method which provides the three constructors; i) constructor for the BuildCommand
      * if copy/update is called, ii) constructor for the BuildCommand if blank/base is called
      * and iii) constructor for the entity.
+     *
+     * If not overridden, a set of builderConstructors is generated automatically.
+     * See {@link #generateDefaultBuilderConstructors()} for more info on builder construction generation.
      * @return the instance containing the three constructor lambdas.
      */
-    public abstract BuilderConstructors<T, BC> constructors();
+    public BuilderConstructors<T, BC> constructors() {
+        if (defaultBuilderConstructors ==  null) {
+            // Lazily generate builderConstructors the first time they're needed.
+            defaultBuilderConstructors = generateDefaultBuilderConstructors();
+        }
+        return defaultBuilderConstructors;
+    }
 
     /**
      * Returns the entity wrapped in a BuildCommand. All fields which are required for
@@ -142,5 +161,72 @@ public abstract class AbstractBuilder<T extends Persistable, BC extends Abstract
                 throw new RuntimeException("Cannot find id field in the hierarchy.", e);
             }
         }
+    }
+
+    /**
+     * Generates a default pair of builder constructors.
+     * The constructor has three methods, which do the following:
+     * i) constructor for copy/update: Instantiates the buildCommand (using its no-args constructor) with the linked entity
+     * ii) constructor for blank/base: Instantiates the buildCommand (using its no-args constructor) with the supplied entity
+     * iii) constructor for the entity: Instantiates the entity (using its no-args constructor).
+     * @return Builder constructor for the entity type and build command type of this class.
+     */
+    @SuppressWarnings("unchecked")
+    private BuilderConstructors<T, BC> generateDefaultBuilderConstructors() {
+        Class<?>[] genericTypes = GenericTypeResolver.resolveTypeArguments(getClass(), AbstractBuilder.class);
+        Assert.isTrue(genericTypes != null && genericTypes.length == 2, "The AbstractBuilder class must contain exactly two class-level generic types");
+
+        Class<?> entityClass = genericTypes[0];
+        Class<?> buildCommandClass = genericTypes[1];
+
+        // Function 1: Returns a new BuildCommand from an Entity.
+        Function<T, BC> directEntityBuilderFunction = (entity -> instantiateBuildCommand(buildCommandClass, entity));
+
+        // Function 2: Returns a new BuildCommand from a supplied Entity.
+        Function<Supplier<T>, BC> lazySupplyingEntityBuilderFunction = (entity -> instantiateBuildCommand(buildCommandClass, entity.get()));
+
+        // Function 3: Returns a new Entity
+        Supplier<T> entitySupplyingFunction = () -> (T) BeanUtils.instantiateClass(entityClass);
+
+        return new BuilderConstructors<>(directEntityBuilderFunction, lazySupplyingEntityBuilderFunction, entitySupplyingFunction);
+    }
+
+    /**
+     * Instantiates a BuildCommand given its class and an initial Entity
+     * This is done by looking at the no-args constructor (either present in {@link AbstractBuildCommand} or overridden in your own BuildCommand)
+     * @param buildCommandClass Class of the BuildCommand to instantiate
+     * @param entity Entity to set within the "entity" field
+     * @return Instantiated BuildCommand for the given Entity
+     */
+    @SuppressWarnings("unchecked")
+    private BC instantiateBuildCommand(Class<?> buildCommandClass, T entity) {
+        BC buildCommand;
+
+        try {
+            // If the buildCommand is a separate class (that is: not an inner class), directly instantiate it.
+            buildCommand = (BC) BeanUtils.instantiateClass(buildCommandClass);
+        } catch (BeanInstantiationException e) {
+            try {
+                // The buildCommand can be an inner class. In that case, look for the constructor taking its outer class as parameter.
+                Constructor innerClassConstructor = ReflectionUtils.accessibleConstructor(buildCommandClass, this.getClass());
+                buildCommand = (BC) BeanUtils.instantiateClass(innerClassConstructor, this);
+            } catch (NoSuchMethodException e2) {
+                // If the buildCommand cannot be instantiated as regular class or as inner class, throw an exception.
+                throw new BeanInstantiationException(buildCommandClass, "A no-args constructor is required!");
+            }
+        }
+
+        // Once the command has been instantiated, place the entity and "updating" field inside it (this is what the overridable constructors also do).
+        Field entityField = ReflectionUtils.findField(buildCommandClass, "entity");
+        Field updatingField = ReflectionUtils.findField(buildCommandClass, "updating");
+        Assert.isTrue(entityField != null, "BuildCommand class or its superclass does not contain the required field 'entity'");
+        Assert.isTrue(updatingField != null, "BuildCommand class or its superclass does not contain the required field 'updating'");
+        entityField.setAccessible(true);
+        updatingField.setAccessible(true);
+
+        ReflectionUtils.setField(entityField, buildCommand, entity);
+        ReflectionUtils.setField(updatingField, buildCommand, !entity.isNew());
+
+        return buildCommand;
     }
 }

--- a/src/test/java/nl/_42/heph/AbstractBuilderTest.java
+++ b/src/test/java/nl/_42/heph/AbstractBuilderTest.java
@@ -1,0 +1,121 @@
+package nl._42.heph;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import nl._42.heph.shared.AbstractSpringTest;
+
+import org.junit.Test;
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public class AbstractBuilderTest extends AbstractSpringTest {
+
+    /**
+     * Test if the generation of default builderConstructors fails if we only provide a custom constructor in our buildCommand and not override the
+     * {@link AbstractBuilder#constructors()} method in the {@link AbstractBuilder} implementation.
+     */
+    @Test
+    public void generateDefaultBuilderConstructors_shouldThrowError_becauseNoDefaultConstructorIsAvailable() {
+
+        AbstractBuilder<MyEntity, MyBuildCommand> myBuilder = new AbstractBuilder<MyEntity, MyBuildCommand>() {
+            @Override
+            public MyBuildCommand base() {
+                return new MyBuildCommand(42L);
+            }
+        };
+
+        try {
+            BuilderConstructors<MyEntity, MyBuildCommand> builderConstructors = myBuilder.constructors();
+            builderConstructors.getConstructorTakingEntity().apply(new MyEntity(44L));
+            fail("Expected BeanInstantiationException was not thrown");
+        } catch (BeanInstantiationException e) {
+            assertEquals("Failed to instantiate [nl._42.heph.AbstractBuilderTest$MyBuildCommand]: A no-args constructor is required!", e.getMessage());
+        }
+
+        try {
+            BuilderConstructors<MyEntity, MyBuildCommand> builderConstructors = myBuilder.constructors();
+            builderConstructors.getConstructorTakingSupplier().apply(() -> new MyEntity(42L));
+            fail("Expected BeanInstantiationException was not thrown");
+        } catch (BeanInstantiationException e) {
+            assertEquals("Failed to instantiate [nl._42.heph.AbstractBuilderTest$MyBuildCommand]: A no-args constructor is required!", e.getMessage());
+        }
+
+        try {
+            BuilderConstructors<MyEntity, MyBuildCommand> builderConstructors = myBuilder.constructors();
+            builderConstructors.getEntityConstructor().get();
+            fail("Expected BeanInstantiationException was not thrown");
+        } catch (BeanInstantiationException e) {
+            assertTrue(e.getMessage().contains("Failed to instantiate [nl._42.heph.AbstractBuilderTest$MyEntity]: No default constructor found;"));
+        }
+
+    }
+
+
+    /**
+     * Test if the usage of custom builderConstructors works as intended for a class of which no default BuilderConstructors can be generated.
+     */
+    @Test
+    public void generateDefaultBuilderConstructors_shouldWorkCorrectly_becauseCustomConstructorsAreSpecified() {
+
+        AbstractBuilder<MyEntity, MyBuildCommand> myBuilder = new AbstractBuilder<MyEntity, MyBuildCommand>() {
+            @Override
+            public MyBuildCommand base() {
+                return new MyBuildCommand(42L);
+            }
+
+            @Override
+            public BuilderConstructors<MyEntity, MyBuildCommand> constructors() {
+                return new BuilderConstructors<>((e -> new MyBuildCommand(e.getId())), (e -> new MyBuildCommand(e.get().getId())), () -> new MyEntity(48L));
+            }
+        };
+
+        BuilderConstructors<MyEntity, MyBuildCommand> builderConstructors = myBuilder.constructors();
+
+        assertEquals(42L, builderConstructors.getConstructorTakingEntity().apply(new MyEntity(42L)).myLong, 0L);
+        assertEquals(45L, builderConstructors.getConstructorTakingSupplier().apply(() -> new MyEntity(45L)).myLong, 0L);
+        assertEquals(48L, builderConstructors.getEntityConstructor().get().getId(), 0);
+
+    }
+
+    private class MyEntity implements Persistable<Long> {
+
+        private final Long id;
+
+        private MyEntity(Long id) {
+            this.id = id;
+        }
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public boolean isNew() {
+            return id != null;
+        }
+    }
+
+    private class MyBuildCommand extends AbstractBuildCommand<MyEntity> {
+
+        private final Long myLong;
+
+        // This prevents a default construction from being available and should throw an error when generating the default builderConstructors
+        private MyBuildCommand(Long myLong) {
+            this.myLong = myLong;
+        }
+
+        @Override
+        protected JpaRepository<MyEntity, Long> getRepository() {
+            return null;
+        }
+
+        @Override
+        protected MyEntity findEntity(MyEntity entity) {
+            return entity;
+        }
+    }
+}

--- a/src/test/java/nl/_42/heph/builder/OrganizationBuilderTest.java
+++ b/src/test/java/nl/_42/heph/builder/OrganizationBuilderTest.java
@@ -2,6 +2,7 @@ package nl._42.heph.builder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 
 import java.util.List;
 
@@ -34,6 +35,17 @@ public class OrganizationBuilderTest extends AbstractSpringTest {
         List<Organization> organizations = organizationRepository.findAll();
         assertEquals(1, organizations.size());
         assertEquals(organization.getName(), organizations.get(0).getName());
+    }
+
+    @Test
+    public void copy() {
+        final String expectedName = "Fourty four";
+        Organization fortyTwo = organizationBuilder._42();
+        Organization fortyFour = organizationBuilder.copy(fortyTwo)
+                .withName(expectedName)
+                .create();
+        assertNotSame(fortyTwo.getId(), fortyFour.getId());
+        assertNotSame(fortyTwo.getName(), fortyFour.getName());
     }
 
 }

--- a/src/test/java/nl/_42/heph/builder/PersonBuilder.java
+++ b/src/test/java/nl/_42/heph/builder/PersonBuilder.java
@@ -30,15 +30,6 @@ public class PersonBuilder extends AbstractBuilder<Person, PersonBuilder.PersonB
     private WorkspaceBuilder workspaceBuilder = new WorkspaceBuilder();
 
     @Override
-    public BuilderConstructors<Person, PersonBuildCommand> constructors() {
-        return new BuilderConstructors<>(
-                PersonBuildCommand::new,
-                PersonBuildCommand::new,
-                Person::new
-        );
-    }
-
-    @Override
     public PersonBuildCommand base() {
         return blank()
                 .withName(EXPECTED_NAME)
@@ -52,14 +43,6 @@ public class PersonBuilder extends AbstractBuilder<Person, PersonBuilder.PersonB
     }
 
     class PersonBuildCommand extends AbstractBuildCommand<Person> {
-
-        public PersonBuildCommand(Person entity) {
-            super(entity);
-        }
-
-        public PersonBuildCommand(Supplier<Person> entity) {
-            super(entity);
-        }
 
         @Override
         protected JpaRepository<Person, ? extends Serializable> getRepository() {

--- a/src/test/java/nl/_42/heph/builder/PersonBuilderTest.java
+++ b/src/test/java/nl/_42/heph/builder/PersonBuilderTest.java
@@ -3,9 +3,13 @@ package nl._42.heph.builder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.function.Supplier;
 
+import javax.persistence.EntityNotFoundException;
+
+import nl._42.heph.AbstractBuildCommand;
 import nl._42.heph.domain.Organization;
 import nl._42.heph.domain.OrganizationRepository;
 import nl._42.heph.domain.Person;
@@ -14,6 +18,7 @@ import nl._42.heph.shared.AbstractSpringTest;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public class PersonBuilderTest extends AbstractSpringTest {
 


### PR DESCRIPTION
AbstractBuilder can now automatically generate the required
`BuilderConstructors` used to obtain references to a `BuildCommand` given an
Entity. This is done by accessing the no-args constructor of the entity
and the BuildCommand class.

For customization and backwards compatibility, it's still possible to
override the `constructors()` method of `AbstractBuilder` and supply
your own set of `BuilderConstructors`

Fixes #4