### PR TITLE
Now automatically retrieves a JpaRepository for the given entity class

### DIFF
--- a/src/test/java/nl/_42/heph/AbstractBuilderTest.java
+++ b/src/test/java/nl/_42/heph/AbstractBuilderTest.java
@@ -1,17 +1,29 @@
 package nl._42.heph;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.Serializable;
+import java.lang.reflect.Field;
+
+import nl._42.heph.domain.Person;
 import nl._42.heph.shared.AbstractSpringTest;
 
 import org.junit.Test;
 import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.util.ReflectionUtils;
 
 public class AbstractBuilderTest extends AbstractSpringTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
 
     /**
      * Test if the generation of default builderConstructors fails if we only provide a custom constructor in our buildCommand and not override the
@@ -32,7 +44,7 @@ public class AbstractBuilderTest extends AbstractSpringTest {
             builderConstructors.getConstructorTakingEntity().apply(new MyEntity(44L));
             fail("Expected BeanInstantiationException was not thrown");
         } catch (BeanInstantiationException e) {
-            assertEquals("Failed to instantiate [nl._42.heph.AbstractBuilderTest$MyBuildCommand]: A no-args constructor is required!", e.getMessage());
+            assertEquals("Failed to instantiate [nl._42.heph.AbstractBuilderTest$MyBuildCommand]: The class may not be private and a no-args constructor (present by default) is required!", e.getMessage());
         }
 
         try {
@@ -40,7 +52,7 @@ public class AbstractBuilderTest extends AbstractSpringTest {
             builderConstructors.getConstructorTakingSupplier().apply(() -> new MyEntity(42L));
             fail("Expected BeanInstantiationException was not thrown");
         } catch (BeanInstantiationException e) {
-            assertEquals("Failed to instantiate [nl._42.heph.AbstractBuilderTest$MyBuildCommand]: A no-args constructor is required!", e.getMessage());
+            assertEquals("Failed to instantiate [nl._42.heph.AbstractBuilderTest$MyBuildCommand]: The class may not be private and a no-args constructor (present by default) is required!", e.getMessage());
         }
 
         try {
@@ -80,6 +92,70 @@ public class AbstractBuilderTest extends AbstractSpringTest {
 
     }
 
+    @Test
+    public void generateRepositorySupplierFunction_repositoryAvailable_shouldReturnRepositoryAndUnsetLookupFunction() {
+
+        TestPersonBuilder myBuilder = new TestPersonBuilder();
+        applicationContext.getAutowireCapableBeanFactory().autowireBean(myBuilder);
+
+        // Test if a repository lookup function has been generated
+        TestPersonBuilder.TestPersonBuildCommand testPersonBuildCommand = myBuilder.constructors().getConstructorTakingEntity().apply(new Person());
+
+        Field repositorySupplierField = ReflectionUtils.findField(MyBuildCommand.class, "repositorySupplier");
+        assertNotNull(repositorySupplierField);
+
+        repositorySupplierField.setAccessible(true);
+
+        assertNotNull(ReflectionUtils.getField(repositorySupplierField, testPersonBuildCommand));
+
+        // There is a repository for 'MyEntity'. The call to getRepository() should return the repository and remove the repository lookup function from this instance of MyBuildCommand
+        JpaRepository<Person, ? extends Serializable> repository = testPersonBuildCommand.getRepository();
+        assertNotNull(repository);
+        assertEquals(0, repository.findAll().size());
+
+        myBuilder.base().create();
+        assertEquals(1, repository.findAll().size());
+
+        assertNull(ReflectionUtils.getField(repositorySupplierField, testPersonBuildCommand));
+
+        // Even without lookup function it should still return the repository.
+        assertEquals(repository, testPersonBuildCommand.getRepository());
+    }
+
+    @Test
+    public void generateRepositorySupplierFunction_noRepositoryAvailable_shouldReturnNullAndUnsetLookupFunction() {
+        AbstractBuilder<MyEntity, MyBuildCommand> myBuilder = new AbstractBuilder<MyEntity, MyBuildCommand>() {
+
+            @Override
+            public MyBuildCommand base() {
+                return new MyBuildCommand(42L);
+            }
+
+            // Required to override, as myBuildCommand does not have the required no-args constructor to auto-generate BuilderConstructors with.
+            @Override
+            public BuilderConstructors<MyEntity, MyBuildCommand> constructors() {
+                return new BuilderConstructors<>((e -> new MyBuildCommand(e.getId())), (e -> new MyBuildCommand(e.get().getId())), () -> new MyEntity(48L));
+            }
+        };
+
+        // Test if a repository lookup function has been generated
+        MyBuildCommand myBuildCommand = myBuilder.constructors().getConstructorTakingEntity().apply(new MyEntity(42L));
+
+        Field repositorySupplierField = ReflectionUtils.findField(MyBuildCommand.class, "repositorySupplier");
+        assertNotNull(repositorySupplierField);
+
+        repositorySupplierField.setAccessible(true);
+
+        assertNotNull(ReflectionUtils.getField(repositorySupplierField, myBuildCommand));
+
+        // There is no repository for 'MyEntity'. The call to getRepository() should return null and remove the repository lookup function from this instance of MyBuildCommand
+        assertNull(myBuildCommand.getRepository());
+        assertNull(ReflectionUtils.getField(repositorySupplierField, myBuildCommand));
+
+        // Even without lookup function it should still return null.
+        assertNull(myBuildCommand.getRepository());
+    }
+
     private class MyEntity implements Persistable<Long> {
 
         private final Long id;
@@ -109,13 +185,27 @@ public class AbstractBuilderTest extends AbstractSpringTest {
         }
 
         @Override
-        protected JpaRepository<MyEntity, Long> getRepository() {
-            return null;
-        }
-
-        @Override
         protected MyEntity findEntity(MyEntity entity) {
             return entity;
         }
     }
+
+    // Test / mock version of PersonBuilder which always saves entities to the database.
+    private class TestPersonBuilder extends AbstractBuilder<Person, TestPersonBuilder.TestPersonBuildCommand> {
+
+        @Override
+        public TestPersonBuildCommand base() {
+            return blank();
+        }
+
+        class TestPersonBuildCommand extends AbstractBuildCommand<Person> {
+
+            @Override
+            protected Person findEntity(Person entity) {
+                return null; // Force repository to save new entity.
+            }
+        }
+    }
+
+
 }

--- a/src/test/java/nl/_42/heph/builder/PersonBuilder.java
+++ b/src/test/java/nl/_42/heph/builder/PersonBuilder.java
@@ -1,11 +1,8 @@
 package nl._42.heph.builder;
-
-import java.io.Serializable;
 import java.util.function.Supplier;
 
 import nl._42.heph.AbstractBuildCommand;
 import nl._42.heph.AbstractBuilder;
-import nl._42.heph.BuilderConstructors;
 import nl._42.heph.LazyEntityId;
 import nl._42.heph.LazyEntityReference;
 import nl._42.heph.domain.Organization;
@@ -14,7 +11,6 @@ import nl._42.heph.domain.PersonRepository;
 import nl._42.heph.domain.Workspace;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -43,11 +39,6 @@ public class PersonBuilder extends AbstractBuilder<Person, PersonBuilder.PersonB
     }
 
     class PersonBuildCommand extends AbstractBuildCommand<Person> {
-
-        @Override
-        protected JpaRepository<Person, ? extends Serializable> getRepository() {
-            return personRepository;
-        }
 
         @Override
         protected Person findEntity(Person entity) {


### PR DESCRIPTION
When creating a BuildCommand, it is no longer required to override the
method `getRepository()`. The repository is now looked up using the
`Repositories` class from the Spring Framework.

If no repository is available, the builder still works. You can also
still override the `getRepository()` method in your buildCommand to
return a customized repository instance (or disable the repository on
purpose)