### PR TITLE
Fixed ClassCastException when passing a Supplier of a collection type

### DIFF
--- a/src/main/java/nl/_42/heph/lazy/AbstractLazyEntity.java
+++ b/src/main/java/nl/_42/heph/lazy/AbstractLazyEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.domain.Persistable;
  * @param <T> the type of the entity
  * @param <A> the type of the value to store (can either be also the entity, or Long)
  */
-public abstract class AbstractLazyEntity<T extends Persistable, A> implements LazyEntity {
+public abstract class AbstractLazyEntity<T, A> implements LazyEntity {
 
     /**
      * the supplier that returns the currently set value. Used to determine if the

--- a/src/main/java/nl/_42/heph/lazy/LazyEntityReference.java
+++ b/src/main/java/nl/_42/heph/lazy/LazyEntityReference.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Persistable;
  * reference will be resolved and set using the the setter consumer.
  * @param <T> classtype of the entity that is being resolved
  */
-public class LazyEntityReference<T extends Persistable> extends AbstractLazyEntity<T,T> {
+public class LazyEntityReference<T> extends AbstractLazyEntity<T,T> {
 
     public LazyEntityReference(Supplier<T> getter, Consumer<T> setter, Supplier<T> reference) {
         super(getter, setter, reference);

--- a/src/test/java/nl/_42/heph/builder/OrganizationBuildCommand.java
+++ b/src/test/java/nl/_42/heph/builder/OrganizationBuildCommand.java
@@ -1,6 +1,7 @@
 package nl._42.heph.builder;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import nl._42.heph.AbstractBuildCommand;
@@ -34,7 +35,10 @@ public interface OrganizationBuildCommand extends AbstractBuildCommand<Organizat
     OrganizationBuildCommand withContactPersons(Person... contactPersons);
 
     // Collection -> Collection
-    OrganizationBuildCommand withContactPersons(Collection<?> contactPersons);
+    OrganizationBuildCommand withContactPersons(Collection<Person> contactPersons);
+
+    // Supplier -> Collection
+    OrganizationBuildCommand withContactPersons(Supplier<Set<Person>> contactPersons);
 
     // Array -> Array
     OrganizationBuildCommand withLegalIdentityNumbers(String[] legalIdentityNumbers);

--- a/src/test/java/nl/_42/heph/builder/OrganizationFixtures.java
+++ b/src/test/java/nl/_42/heph/builder/OrganizationFixtures.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import nl._42.heph.AbstractBuilder;
 import nl._42.heph.domain.Organization;
 
+import org.assertj.core.util.Sets;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -56,6 +57,13 @@ public class OrganizationFixtures extends AbstractBuilder<Organization, Organiza
         return base()
                 .withCustomName("Orange")
                 .withOwner(() -> personFixtures.base().withName("E").create())
+                .create();
+    }
+
+    public Organization orange_withMultipleContactPersons() {
+        return blank()
+                .withName("Orange")
+                .withContactPersons(() -> Sets.newHashSet(Arrays.asList(personFixtures.base().withName("F").create(), personFixtures.base().withName("G").create())))
                 .create();
     }
 }

--- a/src/test/java/nl/_42/heph/builder/OrganizationFixturesTest.java
+++ b/src/test/java/nl/_42/heph/builder/OrganizationFixturesTest.java
@@ -64,6 +64,16 @@ public class OrganizationFixturesTest extends AbstractSpringTest {
     }
 
     @Test
+    public void collectionMappings_shouldResolveSuppliedCollectionCorrectly() {
+        Organization orangeWithMultipleContactPersons = organizationFixtures.orange_withMultipleContactPersons();
+
+        assertEquals("Orange", orangeWithMultipleContactPersons.getName());
+        assertEquals(2, orangeWithMultipleContactPersons.getContactPersons().size());
+        assertTrue(orangeWithMultipleContactPersons.getContactPersons().stream().anyMatch(p -> p.getName().equals("F")));
+        assertTrue(orangeWithMultipleContactPersons.getContactPersons().stream().anyMatch(p -> p.getName().equals("G")));
+    }
+
+    @Test
     public void customWithMethod_suppliedOwner_shouldExecuteWithMethodAndResolveBeforeFindReference() {
         Organization customOrange = organizationFixtures.orange_customNamed();
 


### PR DESCRIPTION
If an entity has a collection type of nested entities (e.g. `OneToMany`
or `ManyToMany` mapping), you should be able to pass the set of nested
entities as a supplied collection to prevent unneccessary entity
creation in deeper tree structures.

However, the type of `AbstractLazyEntity` was bound to Persistable,
preventing passing of a `Collection` inside it.

This commit removes that restriction and now allows passing Collections
in a Supplier function. A test case has been written as well.

Fixes #14