### PR TITLE
Removed hard dependency on BeanMapper

### DIFF
--- a/src/test/java/nl/_42/heph/NoBeanMapperMockClassLoader.java
+++ b/src/test/java/nl/_42/heph/NoBeanMapperMockClassLoader.java
@@ -1,0 +1,17 @@
+package nl._42.heph;
+
+/**
+ * Mocked ClassLoader which does not load the class used to detect if BeanMapper is on the classpath.
+ * This way, we can test if the copy() method throws the correct error in such cases.
+ */
+public class NoBeanMapperMockClassLoader extends ClassLoader {
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        if (name == null || name.equals("io.beanmapper.BeanMapper")) {
+            throw new NoClassDefFoundError();
+        }
+
+        return super.loadClass(name);
+    }
+}

--- a/src/test/java/nl/_42/heph/NoBeanMapperTest.java
+++ b/src/test/java/nl/_42/heph/NoBeanMapperTest.java
@@ -1,0 +1,46 @@
+package nl._42.heph;
+
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.Assert.assertEquals;
+
+import nl._42.heph.builder.PersonFixtures;
+import nl._42.heph.domain.Person;
+import nl._42.heph.shared.AbstractSpringTest;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+public class NoBeanMapperTest extends AbstractSpringTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private PersonFixtures personFixtures;
+
+    /**
+     * This test ensures that the library throws the correct error message if BeanMapper is not on our classpath.
+     */
+    @Test
+    public void noBeanMapperOnClassPath_copyFunctionShouldThrowErrorExplainingHowToResolve() {
+        ClassLoader originalClassLoader = applicationContext.getClassLoader();
+
+        try {
+            ((GenericApplicationContext)applicationContext).setClassLoader(new NoBeanMapperMockClassLoader());
+
+            Person person = personFixtures.sjaak();
+
+            try {
+                personFixtures.copy(person);
+                fail("Expected UnsupportedOperationException was not thrown!");
+            } catch (UnsupportedOperationException e) {
+                assertEquals("The copy feature requires the io.beanmapper dependency to be added to your project. Please include it and then try again.", e.getMessage());
+            }
+        } finally {
+            ((GenericApplicationContext) applicationContext).setClassLoader(originalClassLoader);
+        }
+
+    }
+}


### PR DESCRIPTION
BeanMapper is only required for the `copy` method, but currently it was
a hard dependency of this library. To make things worse, its scope was
`provided`, so you would get a runtime crash if your project did not
include `BeanMapper` by itself.

This has now been solved. If BeanMapper is *not* on the classpath,
everything but the `copy` method can still be used.