### PR TITLE
Upgraded to Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 install: mvn install -DskipTests=true -Dgpg.skip=true
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2019-08-29
+
+- Upgraded to Java 11  
+Java 8 is no longer supported in this version.
+
+
 ## [1.0.1] - 2019-03-18
 ### Fixed
 - Issue [#14](https://github.com/42BV/heph/issues/14) **ClassCastException when passing a `Collection` of entities in a `Supplier` in a `BuildCommand`**; Collections can now be mapped as well.

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </developers>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Dependencies -->
@@ -97,6 +97,26 @@
             <version>${database.truncator.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -117,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -128,7 +148,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -142,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -156,7 +176,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -184,7 +204,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>0.8.4</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/nl/_42/heph/generation/BuildCommandAdvice.java
+++ b/src/main/java/nl/_42/heph/generation/BuildCommandAdvice.java
@@ -51,7 +51,9 @@ public class BuildCommandAdvice implements MethodInterceptor {
         } else {
             // Otherwise, set the generated field value to the internal entity.
             if (args == null || args.length == 0) {
-                throw new IllegalArgumentException(format("Failed to resolve method [%s] in buildCommand of type [%s]: Expected one argument or varargs type, but got none", method.getName(), method.getDeclaringClass().getName()));
+                throw new IllegalArgumentException(
+                        format("Failed to resolve method [%s] in buildCommand of type [%s]: Expected one argument or varargs type, but got none",
+                                method.getName(), method.getDeclaringClass().getName()));
             }
 
             if (args.length == 1) {
@@ -63,7 +65,9 @@ public class BuildCommandAdvice implements MethodInterceptor {
                 return buildCommand.withValue(fieldName, argumentValue, resolveAnnotation, entityFieldAnnotation, entityIdAnnotation);
             }
 
-            throw new IllegalArgumentException(format("Failed to resolve method [%s] in buildCommand of type [%s]: Expected one argument or varargs type, but got multiple arguments", method.getName(), method.getDeclaringClass().getName()));
+            throw new IllegalArgumentException(
+                    format("Failed to resolve method [%s] in buildCommand of type [%s]: Expected one argument or varargs type, but got multiple arguments",
+                            method.getName(), method.getDeclaringClass().getName()));
         }
     }
 
@@ -89,10 +93,9 @@ public class BuildCommandAdvice implements MethodInterceptor {
         final Class<?> declaringClass = method.getDeclaringClass();
 
         try {
-            Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class, int.class);
-            constructor.setAccessible(true);
-            return constructor.newInstance(declaringClass, MethodHandles.Lookup.PRIVATE).unreflectSpecial(method, declaringClass);
-        } catch (IllegalAccessException | NoSuchMethodException | InstantiationException | InvocationTargetException e) {
+            MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(declaringClass, MethodHandles.lookup());
+            return lookup.unreflectSpecial(method, declaringClass);
+        } catch (IllegalAccessException e) {
             throw new IllegalStateException("Could not retrieve method handle. Is the BuildCommand placed in a public interface?", e);
         }
     }

--- a/src/test/java/nl/_42/heph/builder/AncientTribeFixtures.java
+++ b/src/test/java/nl/_42/heph/builder/AncientTribeFixtures.java
@@ -7,7 +7,6 @@ import nl._42.heph.domain.AncientTribe;
 
 public class AncientTribeFixtures extends AbstractBuilder<AncientTribe, AncientTribeBuildCommand> {
 
-
     @Override
     public AncientTribeBuildCommand base() {
         return blank();
@@ -15,16 +14,23 @@ public class AncientTribeFixtures extends AbstractBuilder<AncientTribe, AncientT
 
     AncientTribe himba() {
         return base()
-                .withInhabitantsHaveChildren(new boolean[] {true, false, true})
-                .withPhoto(new byte[] {1, 0, 1, 0, 0, 0, 0, 0, 1})
-                .withInhabitantChildrenCounts(new short[] {5, 0, 2})
-                .withInhabitantAges(new int[] {29, 14, 24})
-                .withInhabitantLengths(new long[] {169, 148, 175})
-                .withInhabitantShoeSizes(new float[] {39.5f, 37, 42f})
-                .withInhabitantWeights(new double[] {65, 50, 74})
-                .withInhabitantInitials(new char[] {'A', 'M', 'D'})
+                .withInhabitantsHaveChildren(new boolean[] { true, false, true })
+                .withPhoto(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 1 })
+                .withInhabitantChildrenCounts(new short[] { 5, 0, 2 })
+                .withInhabitantAges(new int[] { 29, 14, 24 })
+                .withInhabitantLengths(new long[] { 169, 148, 175 })
+                .withInhabitantShoeSizes(new float[] { 39.5f, 37, 42f })
+                .withInhabitantWeights(new double[] { 65, 50, 74 })
+                .withInhabitantInitials(new char[] { 'A', 'M', 'D' })
                 .withInhabitantNames(Arrays.asList("Aaron", "Mustafa", "Dinhi"))
-                .withInhabitantsHaveBeenResearched(new boolean[] {true, true, true})
+                .withInhabitantsHaveBeenResearched(new boolean[] { true, true, true })
+                .construct();
+    }
+
+    AncientTribe doubleInhabitantNames() {
+        return base()
+                .withInhabitantNames(Arrays.asList("Simba", "Mufasa"))
+                .withInhabitantNames(Arrays.asList("Scar", "Nala"))
                 .construct();
     }
 }

--- a/src/test/java/nl/_42/heph/builder/AncientTribeFixturesTest.java
+++ b/src/test/java/nl/_42/heph/builder/AncientTribeFixturesTest.java
@@ -9,19 +9,25 @@ import org.junit.Test;
 
 public class AncientTribeFixturesTest {
 
-
     @Test
     public void testPrimitiveArrayMappings() {
         AncientTribe tribe = new AncientTribeFixtures().himba();
 
-        assertArrayEquals(new boolean[] {true, false, true}, tribe.getInhabitantsHaveChildren());
-        assertArrayEquals(new short[] {5, 0, 2}, tribe.getInhabitantChildrenCounts());
-        assertArrayEquals(new int[] {29, 14, 24}, tribe.getInhabitantAges());
-        assertArrayEquals(new long[] {169, 148, 175}, tribe.getInhabitantLengths());
-        assertArrayEquals(new float[] {39.5f, 37, 42f}, tribe.getInhabitantShoeSizes(), 0.01f);
-        assertArrayEquals(new double[] {65, 50, 74}, tribe.getInhabitantWeights(), 0.01d);
-        assertArrayEquals(new char[] {'A', 'M', 'D'}, tribe.getInhabitantInitials());
-        assertArrayEquals(new String[] {"Aaron", "Mustafa", "Dinhi"}, tribe.getInhabitantNames());
+        assertArrayEquals(new boolean[] { true, false, true }, tribe.getInhabitantsHaveChildren());
+        assertArrayEquals(new short[] { 5, 0, 2 }, tribe.getInhabitantChildrenCounts());
+        assertArrayEquals(new int[] { 29, 14, 24 }, tribe.getInhabitantAges());
+        assertArrayEquals(new long[] { 169, 148, 175 }, tribe.getInhabitantLengths());
+        assertArrayEquals(new float[] { 39.5f, 37, 42f }, tribe.getInhabitantShoeSizes(), 0.01f);
+        assertArrayEquals(new double[] { 65, 50, 74 }, tribe.getInhabitantWeights(), 0.01d);
+        assertArrayEquals(new char[] { 'A', 'M', 'D' }, tribe.getInhabitantInitials());
+        assertArrayEquals(new String[] { "Aaron", "Mustafa", "Dinhi" }, tribe.getInhabitantNames());
         assertTrue(tribe.getInhabitantsHaveBeenResearched().stream().allMatch(b -> b));
+    }
+
+    @Test
+    public void testDoubleArrayAssignation() {
+        AncientTribe tribe = new AncientTribeFixtures().doubleInhabitantNames();
+
+        assertArrayEquals(new String[] { "Simba", "Mufasa", "Scar", "Nala" }, tribe.getInhabitantNames());
     }
 }


### PR DESCRIPTION
Java 8 is no longer supported in this version!

The previous way of reflection used in BuildCommandAdvice is no longer
working in Java 11. This has been replaced with a way that does work.

Setting Arrays also no longer worked. A field of type String[] could
no longer be filled with an Object[] as was possible in Java 8. This
bit has been improved to fill the field with a String[]. The code
detects of what type the field is and creates an Array of said type
accordingly, keeping this dynamic for all types of arrays.